### PR TITLE
Allows passing a connection string as location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ var ReDOWN = require('redown')
 
  var redis_client = redis.createClient(6379, 'localhost');  
 
- var db = levelup('does not matter', { db: ReDOWN, redis: redis_client })
+ // Either a connection string or an existing redis instance must be passed, or the driver will connect to localhost
+ var db = levelup('redis://:@localhost:6379?detect_buffers=false', { db: ReDOWN, redis: redis_client })
 
 db.put('name', 'Yuri Irsenovich Kim')
 db.put('dob', '16 February 1941')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redown",
   "description": "An drop-in replacement for LevelDOWN that works with Redis",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "homepage": "https://github.com/andrew/node-redown",
   "authors": [
     "Andrew Nesbitt <andrewnez@gmail.com> (https://github.com/andrew)"
@@ -20,6 +20,7 @@
   "dependencies": {
     "abstract-leveldown": "~2.1.0",
     "bops": "~0.1.0",
+    "qs": "^2.4.1",
     "redis": "~0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows a connection string to be passed in place of a location

The string needs to be in the following format

redis://[:password@]host[:port]/[?options]

The query string can be any of the createClient options listed on https://github.com/mranney/node_redis
